### PR TITLE
Add license to userscript headers

### DIFF
--- a/plugins/userscript.plugin.ts
+++ b/plugins/userscript.plugin.ts
@@ -23,6 +23,7 @@ interface UserScriptOptions {
     updateURL: string;
     downloadURL: string;
     supportURL: string;
+    license: string;
     include: string[];
     match: string[];
     exclude: string[];
@@ -130,6 +131,10 @@ export function generateHeader() {
     // Add userscript header's supportURL.
     if (userscript.supportURL) {
         headers.push(`// @supportURL ${userscript.supportURL}`);
+    }
+    // Add userscript header's license.
+    if (userscript.license) {
+        headers.push(`// @license ${userscript.license}`);
     }
     // Add userscript header's includes.
     if (userscript.include && userscript.include instanceof Array) {


### PR DESCRIPTION
The template is missing `license` field that is required by many userscript storage services. Let it be there now