### PR TITLE
feat: add keyed resource header support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
       "GM.xmlHttpRequest"
     ],
     "exclude": [],
-    "resources": []
+    "resources": [],
+    "keyedResources": {}
   },
   "dependencies": {
     "@trim21/gm-fetch": "^0.1.13",

--- a/plugins/userscript.plugin.ts
+++ b/plugins/userscript.plugin.ts
@@ -36,6 +36,7 @@ interface UserScriptOptions {
     exclude: string[];
     require: string[];
     resources: string[];
+    keyedResources: { [key: string]: string };
     connect: string[];
     'run-at': string;
     grant: string[];
@@ -207,6 +208,15 @@ export function generateHeader() {
     if (userscript.resources && userscript.resources instanceof Array) {
         for (const resource of userscript.resources) {
             headers.push(`// @resource ${resource}`);
+        }
+    }
+    // Add userscript header's resources.
+    // Some of resources should contain a specified name, for which userscript can get value from it
+    // eg. // @resource mycss http://link.to/some.css
+    // Userscript have the ability to apply css with `GM_addStyle(GM_getResourceText('mycss'))`
+    if (userscript.keyedResources) {
+        for (const dependencyName in userscript.keyedResources) {
+            headers.push(`// @resource ${dependencyName} ${userscript.keyedResources[dependencyName]}`);
         }
     }
     // Add userscript header's connects.

--- a/plugins/userscript.plugin.ts
+++ b/plugins/userscript.plugin.ts
@@ -211,9 +211,9 @@ export function generateHeader() {
         }
     }
     // Add userscript header's resources.
-    // Some of resources should contain a specified name, for which userscript can get value from it
+    // Some of the resources should contain a specified name, for which userscripts can get value from it
     // eg. // @resource mycss http://link.to/some.css
-    // Userscript have the ability to apply css with `GM_addStyle(GM_getResourceText('mycss'))`
+    // Userscripts have the ability to apply css with `GM_addStyle(GM_getResourceText('mycss'))`
     if (userscript.keyedResources) {
         for (const dependencyName in userscript.keyedResources) {
             headers.push(`// @resource ${dependencyName} ${userscript.keyedResources[dependencyName]}`);


### PR DESCRIPTION
Some of the resources should contain a specified name, for which userscripts can get value from it
eg. `// @resource mycss http://link.to/some.css`
Userscripts have the ability to apply css with `GM_addStyle(GM_getResourceText('mycss'))`